### PR TITLE
Use django's MiddlewareMixin for compatibility

### DIFF
--- a/django_switchdb/middleware.py
+++ b/django_switchdb/middleware.py
@@ -2,16 +2,15 @@
 from importlib import import_module
 
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 
 from .database_router import database_cfg
 
 
-class SwitchDatabaseMiddleware(object):
-    def __init__(self, get_response):
-        self.get_response = get_response
+class SwitchDatabaseMiddleware(MiddlewareMixin):
 
-    def __call__(self, request):
+    def process_request(self, request):
         module_path, _, function_name = settings.DATABASE_SELECTOR.rpartition('.')
         try:
             function_for_select_database = getattr(import_module(module_path), function_name)
@@ -19,8 +18,7 @@ class SwitchDatabaseMiddleware(object):
         except AttributeError:
             raise ImportError(settings.DATABASE_SELECTOR)
 
-        response = self.get_response(request)
-
-        del database_cfg.name_database
-
+    def process_response(self, request, response):
+        if hasattr(database_cfg, 'name_database'):
+            del database_cfg.name_database
         return response


### PR DESCRIPTION
This mixin allows a middleware to be compatible with MIDDLEWARES and the
old MIDDLEWARE_CLASSES